### PR TITLE
few lib upgrades and dependabot alert fixes

### DIFF
--- a/ez-up/pom.xml
+++ b/ez-up/pom.xml
@@ -24,22 +24,22 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.12</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>28.2-jre</version>
+			<version>30.1.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.11</version>
+			<version>3.12.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.8</version>
+			<version>1.9</version>
 		</dependency>
 		<dependency>
 			<groupId>io.methvin</groupId>


### PR DESCRIPTION
fix dependabot alerts for guava (to 30.1.1 from 28.2) and httpclient (to 4.5.13 from 4.5.12).

freshen commons-lang3 (to 3.12.0 from 3.11) and -text (to 1.9 from 1.8) while in here.