### PR TITLE
Update dependencies and add maven-compat to the ez-up-testing module …

### DIFF
--- a/ez-up-cli/pom.xml
+++ b/ez-up-cli/pom.xml
@@ -6,7 +6,7 @@
         <artifactId>ez-up-parent</artifactId>
         <groupId>com.rei.ez-up</groupId>
         <version>${revision}</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -25,12 +25,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.14</version>
+            <version>1.5.18</version>
         </dependency>
         <dependency>
-            <groupId>com.beust</groupId>
+            <groupId>org.jcommander</groupId>
             <artifactId>jcommander</artifactId>
-            <version>1.71</version>
+            <version>2.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -38,7 +38,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>1.5.6.RELEASE</version>
+                <version>3.4.4</version>
                 <executions>
                     <execution>
                         <goals>
@@ -50,9 +50,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.7.1</version>
                 <configuration>
-                    <descriptor>src/assembly/assembly.xml</descriptor>
+                    <descriptors>
+                        <descriptor>src/assembly/assembly.xml</descriptor>
+                    </descriptors>
                 </configuration>
                 <executions>
                     <execution>
@@ -65,6 +67,4 @@
             </plugin>
         </plugins>
     </build>
-
-
 </project>

--- a/ez-up-maven-plugin/pom.xml
+++ b/ez-up-maven-plugin/pom.xml
@@ -4,7 +4,7 @@
         <groupId>com.rei.ez-up</groupId>
         <artifactId>ez-up-parent</artifactId>
         <version>${revision}</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>ez-up-maven-plugin</artifactId>
@@ -12,20 +12,19 @@
     <name>EZ-Up Maven Plugin</name>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mvn.version>3.9.7</mvn.version>
         <revision>99999-SNAPSHOT</revision>
     </properties>
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>${mvn.version}</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${mvn.version}</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -46,7 +45,7 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.0</version>
+            <version>3.15.1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -55,7 +54,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.15.1</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
@@ -77,7 +76,7 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-component-metadata</artifactId>
-                <version>2.1.0</version>
+                <version>2.2.0</version>
                 <executions>
                     <execution>
                         <goals>

--- a/ez-up-maven-plugin/src/test/java/com/rei/ezup/AttachIndexMojoTest.java
+++ b/ez-up-maven-plugin/src/test/java/com/rei/ezup/AttachIndexMojoTest.java
@@ -1,28 +1,28 @@
 package com.rei.ezup;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AttachIndexMojoTest {
-    @Rule
-    public TemporaryFolder tmp = new TemporaryFolder();
+    @TempDir
+    public Path tmp;
 
     @Test
     public void execute() throws Exception {
         AttachMarkerMojo mojo = new AttachMarkerMojo();
-        mojo.markerFile = tmp.newFile("test.ezup");
+        mojo.markerFile = new File(tmp.toFile(), "test.ezup");
 
         mojo.project = new MavenProject();
         mojo.project.setGroupId("group.id");

--- a/ez-up-testing/pom.xml
+++ b/ez-up-testing/pom.xml
@@ -5,11 +5,11 @@
 		<groupId>com.rei.ez-up</groupId>
 		<artifactId>ez-up-parent</artifactId>
 		<version>${revision}</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>ez-up-testing</artifactId>
 	<properties>
 		<revision>99999-SNAPSHOT</revision>
-		<aetherVersion>1.0.2.v20150114</aetherVersion>
 	</properties>
 
 	<dependencies>
@@ -26,11 +26,17 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-embedder</artifactId>
-			<version>3.9.6</version>
+			<version>${maven.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.maven</groupId>
+			<artifactId>maven-compat</artifactId>
+			<version>${maven.version}</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/ez-up/pom.xml
+++ b/ez-up/pom.xml
@@ -5,7 +5,7 @@
 		<groupId>com.rei.ez-up</groupId>
 		<artifactId>ez-up-parent</artifactId>
 		<version>${revision}</version>
-		<relativePath>..</relativePath>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>ez-up</artifactId>
 	<name>ez-up</name>
@@ -18,38 +18,33 @@
 		<dependency>
 			<groupId>org.apache.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
-			<version>4.0.20</version>
+			<version>4.0.26</version>
 			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>33.0.0-jre</version>
+			<version>33.4.8-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
+			<version>3.17.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.11.0</version>
+			<version>1.13.1</version>
 		</dependency>
 		<dependency>
 			<groupId>io.methvin</groupId>
 			<artifactId>directory-watcher</artifactId>
-			<version>0.15.0</version>
+			<version>0.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.rei.aether</groupId>
 			<artifactId>aether-utils</artifactId>
-			<version>1.2</version>
+			<version>2.0.2</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/ez-up/src/test/java/com/rei/ezup/TemplateConfigTest.java
+++ b/ez-up/src/test/java/com/rei/ezup/TemplateConfigTest.java
@@ -16,13 +16,14 @@ public class TemplateConfigTest extends BaseTemplateTest {
     @Test
     public void testLoad(@TempDir Path tmp) throws Exception {
         try(TemplateArchive archive = getTestTemplate(tmp)) {
-            EzUpConfig globalConfig = new EzUpConfig(false, false, ImmutableMap.of("global", "true", "includeFoo", "true"));
+            EzUpConfig globalConfig = new EzUpConfig(false, false, ImmutableMap.of("global", "true", "includeFoo", "false"));
 
             TemplateConfig config = TemplateConfig.load(archive, null, globalConfig, tmp);
             Map<String, Object> params = config.getParameterValues();
             System.out.println(params);
             assertEquals(11, params.size());
             assertEquals(1, config.getIncludedFiles().size());
+            assertEquals("**/*", config.getIncludedFiles().get(0));
             assertEquals(1, config.getExcludedFiles().size());
             assertNotNull(params.get("AppName"));
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
 	<parent>
 		<groupId>com.rei.oss</groupId>
 		<artifactId>oss-parent</artifactId>
-		<version>2</version>
+		<version>3</version>
+		<relativePath/>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.rei.ez-up</groupId>
@@ -15,8 +16,9 @@
 	<properties>
 		<revision>99999-SNAPSHOT</revision>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <slf4j.version>1.7.21</slf4j.version>
-		<junit5.version>5.5.2</junit5.version>
+		<maven.version>3.9.9</maven.version>
+		<slf4j.version>2.0.17</slf4j.version>
+		<junit5.version>5.12.2</junit5.version>
 	</properties>
 
 	<modules>
@@ -78,7 +80,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+				<version>3.14.0</version>
 				<configuration>
 					<release>11</release>
 				</configuration>
@@ -86,7 +88,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.1.1</version>
+				<version>3.11.2</version>
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
@@ -95,6 +97,9 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<doclint>all,-missing</doclint>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
The primary reason for this change is to add `maven-compat` as a dependency of the ez-up-testing module to allow for executing Maven goals in tests that consume that dependency and use the `TemplateTester` extension. This change also updates a number of existing dependency and plugin versions, an updates some old Junit 4 test code.